### PR TITLE
REFACTOR: Removing unused next-auth code

### DIFF
--- a/next/src/server/auth.ts
+++ b/next/src/server/auth.ts
@@ -1,15 +1,9 @@
-import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import { type GetServerSidePropsContext } from "next";
 import {
   getServerSession,
   type DefaultSession,
   type NextAuthOptions,
 } from "next-auth";
-import DiscordProvider from "next-auth/providers/discord";
-
-import { env } from "~/env.mjs";
-import { db } from "~/server/db";
-import { mysqlTable } from "~/server/db/schema";
 
 /**
  * Module augmentation for `next-auth` types. Allows us to add custom properties to the `session`
@@ -38,6 +32,7 @@ declare module "next-auth" {
  * @see https://next-auth.js.org/configuration/options
  */
 export const authOptions: NextAuthOptions = {
+  providers: [],
   callbacks: {
     session: ({ session, user }) => ({
       ...session,
@@ -46,23 +41,7 @@ export const authOptions: NextAuthOptions = {
         id: user.id,
       },
     }),
-  },
-  adapter: DrizzleAdapter(db, mysqlTable),
-  providers: [
-    DiscordProvider({
-      clientId: env.DISCORD_CLIENT_ID,
-      clientSecret: env.DISCORD_CLIENT_SECRET,
-    }),
-    /**
-     * ...add more providers here.
-     *
-     * Most other providers require a bit more work than the Discord provider. For example, the
-     * GitHub provider requires you to add the `refresh_token_expires_in` field to the Account
-     * model. Refer to the NextAuth.js docs for the provider you want to use. Example:
-     *
-     * @see https://next-auth.js.org/providers/github
-     */
-  ],
+  }
 };
 
 /**


### PR DESCRIPTION
Currently, build is failing because of missing secrets for next-auth. Authentication will be implemented with a separate issue.